### PR TITLE
데이터베이스 스키마 및 쿼리 개선

### DIFF
--- a/app/common/components/app-sidebar.tsx
+++ b/app/common/components/app-sidebar.tsx
@@ -10,56 +10,47 @@ import { NavMain } from "./nav-main";
 import { NavUser } from "./nav-user";
 import { SidebarFooter, SidebarRail } from "./ui/sidebar";
 import { NavSecondary } from "./nav-secondary";
-
-interface Account {
-  account_id: string;
-  name: string;
-}
-
-interface Profile {
-  name: string;
-  email: string | null;
-}
+import type { Account, Profile } from "~/common/types";
 
 export function AppSidebar({
   accounts,
   profile,
   ...props
-}: React.ComponentProps<typeof Sidebar> & {
+}: {
   accounts: Account[];
   profile: Profile;
-}) {
+} & React.ComponentProps<typeof Sidebar>) {
   const data = {
     navMain: [
       {
         title: "새 가계부",
-        url: `/new`,
+        url: `/account/create`,
         icon: SquarePen,
       },
-      {
-        title: "설정",
-        url: `/settings`,
-        icon: Settings,
-        items: [
-          {
-            title: "General",
-            url: "#",
-            icon: List,
-          },
-          {
-            title: "Team",
-            url: "#",
-          },
-          {
-            title: "Billing",
-            url: "#",
-          },
-          {
-            title: "Limits",
-            url: "#",
-          },
-        ],
-      },
+      // {
+      //   title: "설정",
+      //   url: `/settings`,
+      //   icon: Settings,
+      //   items: [
+      //     {
+      //       title: "General",
+      //       url: "#",
+      //       icon: List,
+      //     },
+      //     {
+      //       title: "Team",
+      //       url: "#",
+      //     },
+      //     {
+      //       title: "Billing",
+      //       url: "#",
+      //     },
+      //     {
+      //       title: "Limits",
+      //       url: "#",
+      //     },
+      //   ],
+      // },
     ],
   };
 
@@ -70,7 +61,7 @@ export function AppSidebar({
       </SidebarHeader>
       <SidebarContent>
         <NavMain items={data.navMain} />
-        <NavSecondary items={accounts} />
+        <NavSecondary accounts={accounts} />
       </SidebarContent>
       <SidebarFooter>
         <NavUser user={profile} />

--- a/app/common/components/bottom-nav-sidebar-layout.tsx
+++ b/app/common/components/bottom-nav-sidebar-layout.tsx
@@ -4,15 +4,16 @@ import BottomNav from "./bottom-nav";
 import type { Route } from "./+types/bottom-nav-sidebar-layout";
 import { SidebarProvider, SidebarInset } from "./ui/sidebar";
 import { AppSidebar } from "./app-sidebar";
-import { getAccounts, getProfile } from "./queries";
+import { getProfile } from "./queries";
 import { makeSSRClient } from "~/supa-client";
 import { getLoggedInUserId } from "~/features/auth/queries";
+import { getAccountsByProfileId } from "~/features/account/queries";
 
 export const loader = async ({ request }: Route.LoaderArgs) => {
   const { client, headers } = makeSSRClient(request);
   const userId = await getLoggedInUserId(client);
   const profile = await getProfile(client, userId);
-  const accounts = await getAccounts(client);
+  const accounts = await getAccountsByProfileId(client, userId);
   return data({ accounts, profile }, { headers });
 };
 
@@ -23,7 +24,7 @@ export default function BottomNavSidebarLayout({
     <SidebarProvider>
       <AppSidebar accounts={loaderData.accounts} profile={loaderData.profile} />
       <SidebarInset>
-        <MobileHeader />
+        <MobileHeader name={loaderData.profile.name} />
         <main className="px-4 py-6 pb-24">
           <Outlet />
         </main>

--- a/app/common/components/mobile-header.tsx
+++ b/app/common/components/mobile-header.tsx
@@ -1,12 +1,21 @@
+import { Link } from "react-router";
 import { ThemeToggle } from "./theme-toggle";
 import { SidebarTrigger } from "./ui/sidebar";
 
-export default function MobileHeader() {
+export default function MobileHeader({ name }: { name: string }) {
   return (
     <header className="sticky top-0 z-50 w-full border-b text-primary bg-background/80 backdrop-blur-sm">
       <div className="flex h-14 items-center px-4 gap-2">
         <SidebarTrigger />
-        <div className="text-2xl font-bold">MOA</div>
+        {name ? (
+          <Link to="/account">
+            <div className="text-2xl font-bold">MOA</div>
+          </Link>
+        ) : (
+          <Link to="/">
+            <div className="text-2xl font-bold">MOA</div>
+          </Link>
+        )}
 
         <div className="flex flex-1 items-center justify-end gap-2">
           <ThemeToggle />

--- a/app/common/components/queries.ts
+++ b/app/common/components/queries.ts
@@ -15,7 +15,7 @@ export const getProfile = async (
 ) => {
   const { data, error } = await client
     .from("profiles")
-    .select(`name, email`)
+    .select(`*`)
     .eq("profile_id", userId)
     .single();
   if (error) throw new Error(error.message);

--- a/app/common/components/sidebar-layout.tsx
+++ b/app/common/components/sidebar-layout.tsx
@@ -3,16 +3,17 @@ import { data, Outlet } from "react-router";
 import { SidebarInset, SidebarProvider } from "~/common/components/ui/sidebar";
 import type { Route } from "./+types/sidebar-layout";
 import { AppSidebar } from "./app-sidebar";
-import { getAccounts, getProfile } from "./queries";
+import { getProfile } from "./queries";
 import { makeSSRClient } from "~/supa-client";
 import { getLoggedInUserId } from "~/features/auth/queries";
 import MobileHeader from "./mobile-header";
+import { getAccountsByProfileId } from "~/features/account/queries";
 
 export const loader = async ({ request }: Route.LoaderArgs) => {
   const { client, headers } = makeSSRClient(request);
   const userId = await getLoggedInUserId(client);
   const profile = await getProfile(client, userId);
-  const accounts = await getAccounts(client);
+  const accounts = await getAccountsByProfileId(client, userId);
   return data({ accounts, profile }, { headers });
 };
 
@@ -21,7 +22,7 @@ export default function SidebarLayout({ loaderData }: Route.ComponentProps) {
     <SidebarProvider>
       <AppSidebar accounts={loaderData.accounts} profile={loaderData.profile} />
       <SidebarInset>
-        <MobileHeader />
+        <MobileHeader name={loaderData.profile.name} />
         <main className="px-4 py-6 pb-24">
           <Outlet />
         </main>

--- a/app/common/components/ui/alert.tsx
+++ b/app/common/components/ui/alert.tsx
@@ -1,0 +1,66 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "~/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border px-4 py-3 text-sm grid has-[>svg]:grid-cols-[calc(var(--spacing)*4)_1fr] grid-cols-[0_1fr] has-[>svg]:gap-x-3 gap-y-0.5 items-start [&>svg]:size-4 [&>svg]:translate-y-0.5 [&>svg]:text-current",
+  {
+    variants: {
+      variant: {
+        default: "bg-card text-card-foreground",
+        destructive:
+          "text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function Alert({
+  className,
+  variant,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof alertVariants>) {
+  return (
+    <div
+      data-slot="alert"
+      role="alert"
+      className={cn(alertVariants({ variant }), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-title"
+      className={cn(
+        "col-start-2 line-clamp-1 min-h-4 font-medium tracking-tight",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDescription({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-description"
+      className={cn(
+        "text-muted-foreground col-start-2 grid justify-items-start gap-1 text-sm [&_p]:leading-relaxed",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Alert, AlertTitle, AlertDescription }

--- a/app/common/components/ui/sonner.tsx
+++ b/app/common/components/ui/sonner.tsx
@@ -1,8 +1,8 @@
-import { useTheme } from "next-themes"
-import { Toaster as Sonner, ToasterProps } from "sonner"
+import { useTheme } from "next-themes";
+import { Toaster as Sonner, type ToasterProps } from "sonner";
 
 const Toaster = ({ ...props }: ToasterProps) => {
-  const { theme = "system" } = useTheme()
+  const { theme = "system" } = useTheme();
 
   return (
     <Sonner
@@ -17,7 +17,7 @@ const Toaster = ({ ...props }: ToasterProps) => {
       }
       {...props}
     />
-  )
-}
+  );
+};
 
-export { Toaster }
+export { Toaster };

--- a/app/common/types.ts
+++ b/app/common/types.ts
@@ -1,0 +1,6 @@
+import type { Database } from "~/supa-client";
+
+// Supabase 클라이언트의 실제 타입 사용
+export type Account =
+  Database["public"]["Views"]["account_budget_list_view"]["Row"];
+export type Profile = Database["public"]["Tables"]["profiles"]["Row"];

--- a/app/features/account/accounts-page.tsx
+++ b/app/features/account/accounts-page.tsx
@@ -2,64 +2,202 @@ import { getLoggedInUserId } from "~/features/auth/queries";
 import { makeSSRClient } from "~/supa-client";
 import type { Route } from "./+types/accounts-page";
 import { getAccountsByProfileId } from "./queries";
-import { Link } from "react-router";
-import { Badge } from "~/common/components/ui/badge";
+import { Link, useFetcher, useNavigate } from "react-router";
+import { toast } from "sonner";
+import { useEffect } from "react";
 import {
   Card,
-  CardAction,
   CardDescription,
   CardFooter,
   CardHeader,
   CardTitle,
 } from "~/common/components/ui/card";
-import { IconChevronRight, IconTrendingUp } from "@tabler/icons-react";
 import { Button } from "~/common/components/ui/button";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "~/common/components/ui/dropdown-menu";
+import {
+  ChevronRight,
+  MoreVertical,
+  Pencil,
+  Plus,
+  Trash,
+  UserPlus,
+} from "lucide-react";
+import { formatCurrency } from "~/lib/utils";
+import { Progress } from "~/common/components/ui/progress";
 
 export const loader = async ({ request }: Route.LoaderArgs) => {
-  const { client } = makeSSRClient(request);
+  const { client, headers } = makeSSRClient(request);
   const userId = await getLoggedInUserId(client);
   const accounts = await getAccountsByProfileId(client, userId);
-  return accounts;
+  return { accounts, headers };
 };
 
 export default function AccountsPage({ loaderData }: Route.ComponentProps) {
-  const accounts = loaderData;
+  const { accounts } = loaderData;
+  const fetcher = useFetcher();
+  const navigate = useNavigate();
+  // fetcher 상태 모니터링
+  useEffect(() => {
+    if (fetcher.state === "idle" && fetcher.data) {
+      // 삭제 성공 시 toast 표시
+      toast.success("가계부가 삭제되었습니다.", {
+        action: {
+          label: "확인",
+          onClick: () => {
+            toast.dismiss();
+          },
+        },
+      });
+      if (fetcher.data.redirectTo) {
+        navigate(fetcher.data.redirectTo);
+      }
+    }
+  }, [fetcher.state, fetcher.data]);
+
+  const onClickDelete = (accountId: string) => {
+    fetcher.submit(
+      { accountId },
+      { method: "post", action: `/account/delete` }
+    );
+  };
+
   return (
-    <div className="flex flex-col gap-4">
-      {accounts.map((account) => (
-        <Link
-          to={`/account/${account.account_id}/dashboard`}
-          key={account.account_id}
-        >
-          <Card className="@container/card">
-            <CardHeader>
-              <CardDescription>{account.name}</CardDescription>
-              <CardTitle className="text-2xl font-semibold tabular-nums @[250px]/card:text-3xl">
-                {account.total_savings.toLocaleString("en-US", {
-                  style: "currency",
-                  currency: account.currency,
-                })}
-              </CardTitle>
+    <div className="flex flex-col gap-6">
+      {/* 계좌 추가 버튼 */}
+      <div className="flex justify-between items-center">
+        <h1 className="text-2xl font-bold">내 가계부</h1>
+        <Link to="/account/create">
+          <Button className="flex items-center gap-2">
+            <Plus size={16} />
+            가계부 추가
+          </Button>
+        </Link>
+      </div>
+
+      {/* 계좌 목록 */}
+      <div className="grid gap-4">
+        {accounts.map((account) => (
+          <Card key={account.account_id} className="@container/card gap-0">
+            <CardHeader className="pb-3">
+              <div className="flex items-start justify-between">
+                <div className="flex-1">
+                  <CardDescription className="text-sm text-muted-foreground">
+                    가계부명
+                  </CardDescription>
+                  <CardTitle className="text-lg font-semibold">
+                    {account.name}
+                  </CardTitle>
+                </div>
+
+                {/* More Vert 메뉴 */}
+                <DropdownMenu>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="sm" className="h-8 w-8 p-0">
+                      <MoreVertical size={16} />
+                      <span className="sr-only">메뉴 열기</span>
+                    </Button>
+                  </DropdownMenuTrigger>
+                  <DropdownMenuContent align="end">
+                    <DropdownMenuItem>
+                      <div className="flex items-center gap-2">
+                        <UserPlus size={16} className="mr-2" />
+                        초대하기
+                      </div>
+                    </DropdownMenuItem>
+                    <DropdownMenuItem>
+                      <Link
+                        to={`/account/${account.account_id}/edit`}
+                        className="flex items-center gap-2"
+                      >
+                        <Pencil size={16} className="mr-2" />
+                        수정하기
+                      </Link>
+                    </DropdownMenuItem>
+                    <DropdownMenuSeparator />
+                    <DropdownMenuItem
+                      className="text-destructive"
+                      onClick={() => onClickDelete(account.account_id)}
+                    >
+                      <Trash size={16} className="mr-2 text-destructive" />
+                      삭제하기
+                    </DropdownMenuItem>
+                  </DropdownMenuContent>
+                </DropdownMenu>
+              </div>
             </CardHeader>
-            <CardFooter className="flex-col items-start gap-1.5 text-sm">
-              <Badge variant="outline" className="bg-green-500/20">
-                +{" "}
-                {account.total_income.toLocaleString("en-US", {
-                  style: "currency",
-                  currency: account.currency,
-                })}
-              </Badge>
-              <Badge variant="outline" className="bg-red-500/20">
-                -{" "}
-                {account.total_expense.toLocaleString("en-US", {
-                  style: "currency",
-                  currency: account.currency,
-                })}
-              </Badge>
+
+            {/* 계좌 정보 */}
+            <div className="px-6 pb-4">
+              <div className="flex items-center justify-between mb-4">
+                <span className="text-sm text-muted-foreground">예산 잔액</span>
+                <span className="text-2xl font-bold tabular-nums @[250px]/card:text-3xl">
+                  {account.current_budget && account.budget_amount ? (
+                    <span className="text-sm text-muted-foreground">
+                      {formatCurrency(
+                        account.budget_amount - account.current_budget
+                      )}
+                    </span>
+                  ) : (
+                    <span className="text-sm text-muted-foreground">
+                      예산 설정 안됨
+                    </span>
+                  )}
+                </span>
+              </div>
+
+              <Progress
+                value={
+                  (((account.budget_amount ?? 0) -
+                    (account.current_budget ?? 0)) /
+                    (account.budget_amount ?? 0)) *
+                  100
+                }
+                className="h-3"
+              />
+            </div>
+
+            {/* 계좌 대시보드로 이동 */}
+            <CardFooter className="pt-0">
+              <Link
+                to={`/account/${account.account_id}/dashboard`}
+                className="w-full"
+              >
+                <Button variant="outline" className="w-full justify-between">
+                  <span>대시보드 보기</span>
+                  <ChevronRight size={16} />
+                </Button>
+              </Link>
             </CardFooter>
           </Card>
-        </Link>
-      ))}
+        ))}
+      </div>
+
+      {/* 계좌가 없을 때 */}
+      {accounts.length === 0 && (
+        <Card className="p-8 text-center">
+          <div className="flex flex-col items-center gap-4">
+            <div className="w-16 h-16 rounded-full bg-muted flex items-center justify-center">
+              <Plus size={24} className="text-muted-foreground" />
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold">가계부가 없습니다</h3>
+              <p className="text-muted-foreground">
+                첫 번째 가계부를 추가하고 재정 관리를 시작해보세요
+              </p>
+            </div>
+            <Button className="flex items-center gap-2">
+              <Plus size={16} />
+              가계부 추가하기
+            </Button>
+          </div>
+        </Card>
+      )}
     </div>
   );
 }

--- a/app/features/account/mutations.ts
+++ b/app/features/account/mutations.ts
@@ -1,0 +1,60 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "~/supa-client";
+
+export const createAccount = async (
+  client: SupabaseClient<Database>,
+  { name, userId }: { name: string; userId: string }
+) => {
+  const { data, error } = await client
+    .from("accounts")
+    .insert({
+      name,
+      created_by: userId,
+    })
+    .select()
+    .single();
+
+  if (error) {
+    throw error;
+  }
+
+  return data;
+};
+
+export const deleteAccount = async (
+  client: SupabaseClient<Database>,
+  { accountId, userId }: { accountId: string; userId: string }
+) => {
+  const { error } = await client
+    .from("accounts")
+    .delete()
+    .eq("account_id", accountId)
+    .eq("created_by", userId);
+  if (error) {
+    throw error;
+  }
+  return { success: true };
+};
+
+export const updateAccount = async (
+  client: SupabaseClient<Database>,
+  {
+    name,
+    userId,
+    accountId,
+  }: { name: string; userId: string; accountId: string }
+) => {
+  const { data, error } = await client
+    .from("accounts")
+    .update({ name })
+    .eq("account_id", accountId)
+    .eq("created_by", userId)
+    .select()
+    .single();
+
+  if (error) {
+    throw error;
+  }
+
+  return data;
+};

--- a/app/features/account/page/create-account-page.tsx
+++ b/app/features/account/page/create-account-page.tsx
@@ -1,0 +1,77 @@
+import { z } from "zod";
+import type { Route } from "./+types/create-account-page";
+import { Link, redirect } from "react-router";
+import { AlertCircleIcon, ChevronLeft } from "lucide-react";
+import { Form } from "react-router";
+import { Button } from "~/common/components/ui/button";
+import { FormInput } from "~/common/components/form-input";
+import { getLoggedInUserId } from "~/features/auth/queries";
+import { makeSSRClient } from "~/supa-client";
+import { createAccount } from "../mutations";
+import {
+  Alert,
+  AlertDescription,
+  AlertTitle,
+} from "~/common/components/ui/alert";
+
+export const meta: Route.MetaFunction = () => {
+  return [
+    { title: "Create Account | MOA" },
+    { name: "description", content: "Create Account Page" },
+  ];
+};
+
+const formSchema = z.object({
+  name: z.string().min(1).max(40),
+});
+
+export const action = async ({ request }: Route.ActionArgs) => {
+  const { client } = makeSSRClient(request);
+  const userId = await getLoggedInUserId(client);
+  const formData = await request.formData();
+  const { success, error, data } = formSchema.safeParse(
+    Object.fromEntries(formData)
+  );
+
+  if (!success) {
+    return { fieldErrors: error.flatten().fieldErrors };
+  }
+
+  const { name } = data;
+  const { account_id } = await createAccount(client, { name, userId });
+  return redirect(`/account/${account_id}/manage`);
+};
+
+export default function CreateAccountPage({
+  actionData,
+}: Route.ComponentProps) {
+  return (
+    <main className="px-4 py-6 h-full min-h-screen space-y-6">
+      <div className="flex items-center gap-2">
+        <Link to={`/account`}>
+          <ChevronLeft className="size-6" />
+        </Link>
+        <h3 className="font-semibold text-lg">가계부 추가</h3>
+      </div>
+      <Form method="post" className="flex flex-col gap-6">
+        <FormInput label="가계부 이름" type="text" name="name" />
+        {actionData && "fieldErrors" in actionData && (
+          <Alert variant="destructive">
+            <AlertCircleIcon />
+            <AlertTitle>가계부 추가 실패</AlertTitle>
+            <AlertDescription>
+              <p>아래 내용을 참고해 이름을 수정해주세요.</p>
+              <ul className="list-inside list-disc text-sm">
+                {actionData.fieldErrors.name &&
+                  actionData.fieldErrors.name.map((error) => (
+                    <li key={error}>{error}</li>
+                  ))}
+              </ul>
+            </AlertDescription>
+          </Alert>
+        )}
+        <Button type="submit">추가</Button>
+      </Form>
+    </main>
+  );
+}

--- a/app/features/account/page/delete-account-page.tsx
+++ b/app/features/account/page/delete-account-page.tsx
@@ -1,0 +1,30 @@
+import type { Route } from "./+types/delete-account-page";
+import { makeSSRClient } from "~/supa-client";
+import { getLoggedInUserId } from "~/features/auth/queries";
+import { z } from "zod";
+import { deleteAccount } from "../mutations";
+
+const formSchema = z.object({
+  accountId: z.string().uuid(),
+});
+
+export const action = async ({ request }: Route.ActionArgs) => {
+  const { client } = makeSSRClient(request);
+  const userId = await getLoggedInUserId(client);
+  const formData = await request.formData();
+  const { success, error, data } = formSchema.safeParse(
+    Object.fromEntries(formData)
+  );
+
+  if (!success) {
+    return { fieldErrors: error.flatten().fieldErrors };
+  }
+
+  const { accountId } = data;
+  const result = await deleteAccount(client, { accountId, userId });
+
+  if (result.success) {
+    return { success: true, redirectTo: "/account" };
+  }
+  return { error: "Failed to delete account" };
+};

--- a/app/features/account/page/edit-account-page.tsx
+++ b/app/features/account/page/edit-account-page.tsx
@@ -1,0 +1,88 @@
+import { Form, Link, redirect } from "react-router";
+import type { Route } from "./+types/edit-account-page";
+import { FormInput } from "~/common/components/form-input";
+import { Button } from "~/common/components/ui/button";
+import { Alert } from "~/common/components/ui/alert";
+import { AlertCircleIcon, ChevronLeft } from "lucide-react";
+import { AlertTitle } from "~/common/components/ui/alert";
+import { AlertDescription } from "~/common/components/ui/alert";
+import { getLoggedInUserId } from "~/features/auth/queries";
+import { makeSSRClient } from "~/supa-client";
+import { z } from "zod";
+import { updateAccount } from "../mutations";
+import { getAccountByIdAndProfileId } from "../queries";
+
+const formSchema = z.object({
+  name: z.string().min(1).max(40),
+});
+
+export const action = async ({ request, params }: Route.ActionArgs) => {
+  const { client } = makeSSRClient(request);
+  const userId = await getLoggedInUserId(client);
+  const { accountId } = params;
+  const formData = await request.formData();
+
+  const { success, error, data } = formSchema.safeParse(
+    Object.fromEntries(formData)
+  );
+
+  if (!success) {
+    return { fieldErrors: error.flatten().fieldErrors };
+  }
+
+  const { name } = data;
+  const result = await updateAccount(client, { name, userId, accountId });
+
+  if (result) {
+    return redirect(`/account/${accountId}/manage`);
+  }
+  return { error: "Failed to update account" };
+};
+
+export const loader = async ({ request, params }: Route.LoaderArgs) => {
+  const { client, headers } = makeSSRClient(request);
+  const userId = await getLoggedInUserId(client);
+  const { accountId } = params;
+  const account = await getAccountByIdAndProfileId(client, accountId, userId);
+  return { account };
+};
+
+export default function EditAccountPage({
+  actionData,
+  loaderData,
+}: Route.ComponentProps) {
+  return (
+    <main className="px-4 py-6 h-full min-h-screen space-y-6">
+      <div className="flex items-center gap-2">
+        <Link to={`/account`}>
+          <ChevronLeft className="size-6" />
+        </Link>
+        <h3 className="font-semibold text-lg">가계부 수정</h3>
+      </div>
+      <Form method="post" className="flex flex-col gap-6">
+        <FormInput
+          label="가계부 이름"
+          type="text"
+          name="name"
+          defaultValue={loaderData?.account?.name}
+        />
+        {actionData && "fieldErrors" in actionData && (
+          <Alert variant="destructive">
+            <AlertCircleIcon />
+            <AlertTitle>가계부 수정 실패</AlertTitle>
+            <AlertDescription>
+              <p>아래 내용을 참고해 이름을 수정해주세요.</p>
+              <ul className="list-inside list-disc text-sm">
+                {actionData?.fieldErrors?.name &&
+                  actionData?.fieldErrors?.name.map((error) => (
+                    <li key={error}>{error}</li>
+                  ))}
+              </ul>
+            </AlertDescription>
+          </Alert>
+        )}
+        <Button type="submit">수정</Button>
+      </Form>
+    </main>
+  );
+}

--- a/app/features/account/queries.ts
+++ b/app/features/account/queries.ts
@@ -1,5 +1,5 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
-import type { Database } from "database.types";
+import type { Database } from "~/supa-client";
 
 export const getAccountsByProfileId = async (
   client: SupabaseClient<Database>,
@@ -9,13 +9,15 @@ export const getAccountsByProfileId = async (
     .from("account_members")
     .select(
       `
-      accounts!inner(
+      account_budget_list_view!inner(
         account_id,
         name,
         currency,
         total_income,
         total_expense,
-        total_savings
+        total_savings,
+        budget_amount,
+        current_budget
       )
     `
     )
@@ -23,6 +25,31 @@ export const getAccountsByProfileId = async (
 
   if (error) throw new Error(error.message);
 
-  // accounts 배열만 추출하여 반환
-  return data?.map((item) => item.accounts) || [];
+  return data?.map((item) => item.account_budget_list_view) || [];
+};
+
+export const getAccountByIdAndProfileId = async (
+  client: SupabaseClient<Database>,
+  accountId: string,
+  profileId: string
+) => {
+  const { data, error } = await client
+    .from("account_members")
+    .select(
+      `
+      accounts!inner(
+      account_id,
+      name,
+      currency,
+      total_income,
+      total_expense,
+      total_savings
+    )
+    `
+    )
+    .eq("account_id", accountId)
+    .eq("profile_id", profileId)
+    .single();
+  if (error) throw new Error(error.message);
+  return data?.accounts;
 };

--- a/app/features/account/schema.ts
+++ b/app/features/account/schema.ts
@@ -10,7 +10,7 @@ import {
 import { profiles } from "../auth/schema";
 
 export const accounts = pgTable("accounts", {
-  account_id: uuid().primaryKey(),
+  account_id: uuid("account_id").primaryKey().defaultRandom(),
   name: text("name").notNull(),
   currency: text("currency").notNull().default("KRW"),
   total_income: bigint({ mode: "number" }).notNull().default(0),
@@ -42,7 +42,7 @@ export const account_members = pgTable(
 );
 
 export const invitations = pgTable("invitations", {
-  invitation_id: uuid().primaryKey(),
+  invitation_id: uuid().primaryKey().defaultRandom(),
   account_id: uuid().references(() => accounts.account_id, {
     onDelete: "cascade",
   }),

--- a/app/features/dashboard/dashboard-page.tsx
+++ b/app/features/dashboard/dashboard-page.tsx
@@ -77,62 +77,79 @@ export default function DashboardPage({ loaderData }: Route.ComponentProps) {
   return (
     <div className="space-y-6">
       {/* 저축 진행률 카드 */}
-      <Card className="rounded-2xl shadow-lg gap-2 bg-gradient-to-br from-emerald-500 to-emerald-600 dark:from-emerald-600 dark:to-emerald-700 border-none text-white">
-        <CardHeader>
-          <CardTitle className="flex items-center justify-between">
-            <h2 className="text-lg font-semibold">저축 목표 진행률</h2>
-            <PiggyBank className="size-6" />
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-3">
-          <div className="flex justify-between items-center">
-            <span className="">현재 금액</span>
-            <span className="text-xl font-bold">
-              {formatCurrency(savingsGoal.current_amount)}
-            </span>
-          </div>
-          <Progress
-            value={(savingsGoal.current_amount / savingsGoal.goal_amount) * 100}
-            className="h-3 [&>div]:bg-white bg-muted/20"
-          />
-          <div className="flex justify-between items-center text-sm">
-            <span>
-              {(
-                (savingsGoal.current_amount / savingsGoal.goal_amount) *
-                100
-              ).toFixed(1)}
-              % 달성
-            </span>
-            <span>목표: {formatCurrency(savingsGoal.goal_amount)}</span>
-          </div>
-        </CardContent>
-      </Card>
+      {savingsGoal && (
+        <Card className="rounded-2xl shadow-lg gap-2 bg-gradient-to-br from-emerald-500 to-emerald-600 dark:from-emerald-600 dark:to-emerald-700 border-none text-white">
+          <CardHeader>
+            <CardTitle className="flex items-center justify-between">
+              <h2 className="text-lg font-semibold">저축 목표 진행률</h2>
+              <PiggyBank className="size-6" />
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <div className="flex justify-between items-center">
+              <span className="">현재 금액</span>
+              <span className="text-xl font-bold">
+                {formatCurrency(savingsGoal.current_amount)}
+              </span>
+            </div>
+            <Progress
+              value={
+                (savingsGoal.current_amount / savingsGoal.goal_amount) * 100
+              }
+              className="h-3 [&>div]:bg-white bg-muted/20"
+            />
+            <div className="flex justify-between items-center text-sm">
+              <span>
+                {(
+                  (savingsGoal.current_amount / savingsGoal.goal_amount) *
+                  100
+                ).toFixed(1)}
+                % 달성
+              </span>
+              <span>목표: {formatCurrency(savingsGoal.goal_amount)}</span>
+            </div>
+          </CardContent>
+        </Card>
+      )}
 
       {/* 저축 계획 요약 */}
-      <div className="grid grid-cols-2 gap-4">
-        <Card className="p-4 rounded-xl shadow-none border gap-2">
-          <div className="flex items-center space-x-2 mb-2">
-            <TrendingUp className="w-4 h-4" />
-            <span className="text-sm text-muted-foreground">월 저축 가능</span>
-          </div>
-          <div className="text-lg font-bold">
-            {formatCurrency(account.total_savings)}
-          </div>
-        </Card>
-        <Card className="p-4 rounded-xl shadow-none border gap-2">
-          <div className="flex items-center space-x-2 mb-2">
-            <Calendar className="size-4" />
-            <span className="text-sm text-muted-foreground">목표 달성까지</span>
-          </div>
-          <div className="text-lg font-bold">
-            {Math.ceil(
-              (savingsGoal.goal_amount - savingsGoal.current_amount) /
-                account.total_savings
-            )}
-            개월
-          </div>
-        </Card>
-      </div>
+      {savingsGoal && (
+        <div className="grid grid-cols-2 gap-4">
+          <Card className="p-4 rounded-xl shadow-none border gap-2">
+            <div className="flex items-center space-x-2 mb-2">
+              <TrendingUp className="w-4 h-4" />
+              <span className="text-sm text-muted-foreground">
+                월 저축 가능
+              </span>
+            </div>
+            <div className="text-lg font-bold">
+              {formatCurrency(account.total_savings)}
+            </div>
+          </Card>
+          <Card className="p-4 rounded-xl shadow-none border gap-2">
+            <div className="flex items-center space-x-2 mb-2">
+              <Calendar className="size-4" />
+              <span className="text-sm text-muted-foreground">
+                목표 달성까지
+              </span>
+            </div>
+            <div className="text-lg font-bold">
+              {Math.ceil(
+                (savingsGoal.goal_amount - savingsGoal.current_amount) /
+                  account.total_savings
+              )}
+              개월
+            </div>
+          </Card>
+        </div>
+      )}
+      {!savingsGoal && (
+        <div className="flex justify-center items-center h-full">
+          <p className="text-sm text-muted-foreground">
+            저축 목표를 설정해주세요.
+          </p>
+        </div>
+      )}
 
       {/* 비정기 지출 현황 */}
       <Card className="p-6 rounded-2xl shadow-none border gap-2">

--- a/app/features/goal/queries.ts
+++ b/app/features/goal/queries.ts
@@ -9,7 +9,7 @@ export const getSavingsGoal = async (
     .from("goals")
     .select("goal_id, name, goal_amount, current_amount, goal_date")
     .eq("account_id", accountId)
-    .single();
+    .maybeSingle();
   if (error) throw new Error(error.message);
   return data;
 };

--- a/app/features/manage/manage-page.tsx
+++ b/app/features/manage/manage-page.tsx
@@ -11,7 +11,7 @@ import { Button } from "~/common/components/ui/button";
 import { Progress } from "~/common/components/ui/progress";
 import { Separator } from "~/common/components/ui/separator";
 
-import { data, Link, type MetaFunction } from "react-router";
+import { data, Link, redirect, type MetaFunction } from "react-router";
 import type { Route } from "./+types/manage-page";
 import { getAccount, getBudgets } from "./queries";
 import { makeSSRClient } from "~/supa-client";

--- a/app/features/manage/queries.ts
+++ b/app/features/manage/queries.ts
@@ -1,6 +1,7 @@
 import { PAGE_SIZE } from "./constants";
 import type { Database } from "database.types";
 import type { SupabaseClient } from "@supabase/supabase-js";
+import { redirect } from "react-router";
 
 export const getTotalIncome = async (
   client: SupabaseClient<Database>,
@@ -63,7 +64,7 @@ export const getAccount = async (
     )
     .eq("account_id", accountId)
     .single();
-  if (error) throw new Error(error.message);
+  if (error) throw redirect("/account");
   return data;
 };
 

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -17,6 +17,7 @@ import {
   useTheme,
 } from "remix-themes";
 import { cn } from "./lib/utils";
+import { Toaster } from "~/common/components/ui/sonner";
 
 export const links: Route.LinksFunction = () => [
   { rel: "preconnect", href: "https://fonts.googleapis.com" },
@@ -47,6 +48,7 @@ function InnerLayout({ children }: { children: React.ReactNode }) {
         <PreventFlashOnWrongTheme ssrTheme={Boolean(data?.theme)} />
       </head>
       <body>
+        <Toaster position="top-center" />
         {children}
         <ScrollRestoration />
         <Scripts />

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -26,7 +26,10 @@ export default [
     layout("common/components/sidebar-layout.tsx", [
       index("features/account/accounts-page.tsx"),
     ]),
+    route("/create", "features/account/page/create-account-page.tsx"),
+    route("/delete", "features/account/page/delete-account-page.tsx"),
     ...prefix("/:accountId", [
+      route("/edit", "features/account/page/edit-account-page.tsx"),
       layout("common/components/bottom-nav-sidebar-layout.tsx", [
         route("/dashboard", "features/dashboard/dashboard-page.tsx"),
         route("/manage", "features/manage/manage-page.tsx"),

--- a/app/sql/migrations/0007_flaky_arachne.sql
+++ b/app/sql/migrations/0007_flaky_arachne.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "accounts" ALTER COLUMN "account_id" SET DEFAULT gen_random_uuid();--> statement-breakpoint
+ALTER TABLE "invitations" ALTER COLUMN "invitation_id" SET DEFAULT gen_random_uuid();

--- a/app/sql/migrations/meta/0007_snapshot.json
+++ b/app/sql/migrations/meta/0007_snapshot.json
@@ -1,0 +1,675 @@
+{
+  "id": "2409d9ab-97be-40fd-97fa-860f4a63c6d9",
+  "prevId": "ee262e0e-331b-44db-a161-4459e524ac0f",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account_members": {
+      "name": "account_members",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "account_roles",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_members_account_id_accounts_account_id_fk": {
+          "name": "account_members_account_id_accounts_account_id_fk",
+          "tableFrom": "account_members",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "account_members_profile_id_profiles_profile_id_fk": {
+          "name": "account_members_profile_id_profiles_profile_id_fk",
+          "tableFrom": "account_members",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "profile_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "account_members_account_id_profile_id_pk": {
+          "name": "account_members_account_id_profile_id_pk",
+          "columns": [
+            "account_id",
+            "profile_id"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.accounts": {
+      "name": "accounts",
+      "schema": "",
+      "columns": {
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "currency": {
+          "name": "currency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'KRW'"
+        },
+        "total_income": {
+          "name": "total_income",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_expense": {
+          "name": "total_expense",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_savings": {
+          "name": "total_savings",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "accounts_created_by_profiles_profile_id_fk": {
+          "name": "accounts_created_by_profiles_profile_id_fk",
+          "tableFrom": "accounts",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "created_by"
+          ],
+          "columnsTo": [
+            "profile_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invitations": {
+      "name": "invitations",
+      "schema": "",
+      "columns": {
+        "invitation_id": {
+          "name": "invitation_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invitations_account_id_accounts_account_id_fk": {
+          "name": "invitations_account_id_accounts_account_id_fk",
+          "tableFrom": "invitations",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "profile_id": {
+          "name": "profile_id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_profile_id_users_id_fk": {
+          "name": "profiles_profile_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "schemaTo": "auth",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.goals": {
+      "name": "goals",
+      "schema": "",
+      "columns": {
+        "goal_id": {
+          "name": "goal_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "goals_goal_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "goal_amount": {
+          "name": "goal_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_amount": {
+          "name": "current_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "goal_date": {
+          "name": "goal_date",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "goals_account_id_accounts_account_id_fk": {
+          "name": "goals_account_id_accounts_account_id_fk",
+          "tableFrom": "goals",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budget_expenses": {
+      "name": "budget_expenses",
+      "schema": "",
+      "columns": {
+        "budget_expense_id": {
+          "name": "budget_expense_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "budget_expenses_budget_expense_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "budget_id": {
+          "name": "budget_id",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "budget_expenses_budget_id_budgets_budget_id_fk": {
+          "name": "budget_expenses_budget_id_budgets_budget_id_fk",
+          "tableFrom": "budget_expenses",
+          "tableTo": "budgets",
+          "columnsFrom": [
+            "budget_id"
+          ],
+          "columnsTo": [
+            "budget_id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.budgets": {
+      "name": "budgets",
+      "schema": "",
+      "columns": {
+        "budget_id": {
+          "name": "budget_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "budgets_budget_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "budget_amount": {
+          "name": "budget_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "current_amount": {
+          "name": "current_amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "budgets_account_id_accounts_account_id_fk": {
+          "name": "budgets_account_id_accounts_account_id_fk",
+          "tableFrom": "budgets",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.transactions": {
+      "name": "transactions",
+      "schema": "",
+      "columns": {
+        "transaction_id": {
+          "name": "transaction_id",
+          "type": "bigint",
+          "primaryKey": true,
+          "notNull": true,
+          "identity": {
+            "type": "always",
+            "name": "transactions_transaction_id_seq",
+            "schema": "public",
+            "increment": "1",
+            "startWith": "1",
+            "minValue": "1",
+            "maxValue": "9223372036854775807",
+            "cache": "1",
+            "cycle": false
+          }
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "type": {
+          "name": "type",
+          "type": "transaction_types",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "note": {
+          "name": "note",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "occurred_at": {
+          "name": "occurred_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "transactions_account_id_accounts_account_id_fk": {
+          "name": "transactions_account_id_accounts_account_id_fk",
+          "tableFrom": "transactions",
+          "tableTo": "accounts",
+          "columnsFrom": [
+            "account_id"
+          ],
+          "columnsTo": [
+            "account_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.account_roles": {
+      "name": "account_roles",
+      "schema": "public",
+      "values": [
+        "owner",
+        "member"
+      ]
+    },
+    "public.transaction_types": {
+      "name": "transaction_types",
+      "schema": "public",
+      "values": [
+        "income",
+        "expense"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/app/sql/migrations/meta/_journal.json
+++ b/app/sql/migrations/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1755785457081,
       "tag": "0006_lean_ted_forrester",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "7",
+      "when": 1755844182963,
+      "tag": "0007_flaky_arachne",
+      "breakpoints": true
     }
   ]
 }

--- a/app/sql/triggers/on_account_created_trigger.sql
+++ b/app/sql/triggers/on_account_created_trigger.sql
@@ -1,0 +1,18 @@
+create or replace function public.handle_new_account()
+returns trigger
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  if new.created_by is not null then
+    insert into public.account_members (account_id, profile_id, role) values (new.account_id, new.created_by, 'owner');
+  end if;
+  return new;
+end;
+$$;
+
+create trigger on_account_created
+after insert on public.accounts
+for each row
+execute procedure public.handle_new_account();

--- a/app/sql/views/account-budget-list-view.sql
+++ b/app/sql/views/account-budget-list-view.sql
@@ -1,0 +1,13 @@
+CREATE OR REPLACE VIEW account_budget_list_view AS
+SELECT
+    accounts.account_id,
+    accounts.name,
+    accounts.currency,
+    accounts.total_income,
+    accounts.total_expense,
+    accounts.total_savings,
+    sum(budgets.current_amount) as current_budget,
+    sum(budgets.budget_amount) as budget_amount
+FROM accounts
+LEFT JOIN budgets USING (account_id)
+GROUP BY accounts.account_id;

--- a/app/supa-client.ts
+++ b/app/supa-client.ts
@@ -1,10 +1,30 @@
-import type { Database } from "database.types";
+import type { Database as SupabaseDatabase } from "database.types";
 import {
   createBrowserClient,
   createServerClient,
   serializeCookieHeader,
 } from "@supabase/ssr";
 import { parseCookieHeader } from "@supabase/ssr";
+import type { MergeDeep, SetFieldType, SetNonNullable } from "type-fest";
+
+export type Database = MergeDeep<
+  SupabaseDatabase,
+  {
+    public: {
+      Views: {
+        account_budget_list_view: {
+          Row: SetFieldType<
+            SetNonNullable<
+              SupabaseDatabase["public"]["Views"]["account_budget_list_view"]["Row"]
+            >,
+            "current_budget" | "budget_amount",
+            number | null
+          >;
+        };
+      };
+    };
+  }
+>;
 
 export const browserClient = createBrowserClient<Database>(
   process.env.SUPABASE_URL!,

--- a/database.types.ts
+++ b/database.types.ts
@@ -41,6 +41,13 @@ export type Database = {
             foreignKeyName: "account_members_account_id_accounts_account_id_fk"
             columns: ["account_id"]
             isOneToOne: false
+            referencedRelation: "account_budget_list_view"
+            referencedColumns: ["account_id"]
+          },
+          {
+            foreignKeyName: "account_members_account_id_accounts_account_id_fk"
+            columns: ["account_id"]
+            isOneToOne: false
             referencedRelation: "accounts"
             referencedColumns: ["account_id"]
           },
@@ -66,7 +73,7 @@ export type Database = {
           updated_at: string
         }
         Insert: {
-          account_id: string
+          account_id?: string
           created_at?: string
           created_by: string
           currency?: string
@@ -168,6 +175,13 @@ export type Database = {
             foreignKeyName: "budgets_account_id_accounts_account_id_fk"
             columns: ["account_id"]
             isOneToOne: false
+            referencedRelation: "account_budget_list_view"
+            referencedColumns: ["account_id"]
+          },
+          {
+            foreignKeyName: "budgets_account_id_accounts_account_id_fk"
+            columns: ["account_id"]
+            isOneToOne: false
             referencedRelation: "accounts"
             referencedColumns: ["account_id"]
           },
@@ -209,6 +223,13 @@ export type Database = {
             foreignKeyName: "goals_account_id_accounts_account_id_fk"
             columns: ["account_id"]
             isOneToOne: false
+            referencedRelation: "account_budget_list_view"
+            referencedColumns: ["account_id"]
+          },
+          {
+            foreignKeyName: "goals_account_id_accounts_account_id_fk"
+            columns: ["account_id"]
+            isOneToOne: false
             referencedRelation: "accounts"
             referencedColumns: ["account_id"]
           },
@@ -228,7 +249,7 @@ export type Database = {
           created_at?: string
           email: string
           expires_at: string
-          invitation_id: string
+          invitation_id?: string
           token: string
         }
         Update: {
@@ -240,6 +261,13 @@ export type Database = {
           token?: string
         }
         Relationships: [
+          {
+            foreignKeyName: "invitations_account_id_accounts_account_id_fk"
+            columns: ["account_id"]
+            isOneToOne: false
+            referencedRelation: "account_budget_list_view"
+            referencedColumns: ["account_id"]
+          },
           {
             foreignKeyName: "invitations_account_id_accounts_account_id_fk"
             columns: ["account_id"]
@@ -309,6 +337,13 @@ export type Database = {
             foreignKeyName: "transactions_account_id_accounts_account_id_fk"
             columns: ["account_id"]
             isOneToOne: false
+            referencedRelation: "account_budget_list_view"
+            referencedColumns: ["account_id"]
+          },
+          {
+            foreignKeyName: "transactions_account_id_accounts_account_id_fk"
+            columns: ["account_id"]
+            isOneToOne: false
             referencedRelation: "accounts"
             referencedColumns: ["account_id"]
           },
@@ -316,7 +351,19 @@ export type Database = {
       }
     }
     Views: {
-      [_ in never]: never
+      account_budget_list_view: {
+        Row: {
+          account_id: string | null
+          budget_amount: number | null
+          currency: string | null
+          current_budget: number | null
+          name: string | null
+          total_expense: number | null
+          total_income: number | null
+          total_savings: number | null
+        }
+        Relationships: []
+      }
     }
     Functions: {
       [_ in never]: never

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
         "remix-themes": "^2.0.4",
         "sonner": "^2.0.5",
         "tailwind-merge": "^3.3.1",
+        "type-fest": "^4.41.0",
         "vaul": "^1.1.2",
         "zod": "^3.25.64"
       },
@@ -7225,6 +7226,18 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/Wombosvideo"
+      }
+    },
+    "node_modules/type-fest": {
+      "version": "4.41.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
+      "integrity": "sha512-TeTSQ6H5YHvpqVwBRcnLDCBnDOHWYu7IvGbHT6N8AOymcr9PJGjc1GTtiWZTYg0NCgYwvnYWEkVChQAr9bjfwA==",
+      "license": "(MIT OR CC0-1.0)",
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/type-is": {

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "remix-themes": "^2.0.4",
     "sonner": "^2.0.5",
     "tailwind-merge": "^3.3.1",
+    "type-fest": "^4.41.0",
     "vaul": "^1.1.2",
     "zod": "^3.25.64"
   },


### PR DESCRIPTION
- `account_budget_list_view` 뷰를 추가하여 계좌의 예산 정보를 집계합니다.
- `accounts`, `invitations`, `goals` 테이블의 `account_id` 및 `invitation_id` 필드에 기본값으로 UUID 생성기를 설정합니다.
- 계좌 생성 시 자동으로 `account_members` 테이블에 소유자 정보를 추가하는 트리거를 구현합니다.
- 계좌 관련 페이지 및 컴포넌트에서 데이터 쿼리 및 상태 관리를 개선하여 사용자 경험을 향상시킵니다.
- 새로운 계좌 생성 및 삭제 기능을 위한 페이지 및 뮤테이션을 추가합니다.